### PR TITLE
fix(dsb-client-gateway-secrets-engine): return null if aws client isn't instantiated

### DIFF
--- a/libs/dsb-client-gateway-secrets-engine/src/lib/service/aws-secrets-manager.service.ts
+++ b/libs/dsb-client-gateway-secrets-engine/src/lib/service/aws-secrets-manager.service.ts
@@ -243,6 +243,12 @@ export class AwsSecretsManagerService
 
   @Span('aws_ssm_getPrivateKey')
   public async getPrivateKey(): Promise<string | null> {
+    if (!this.client) {
+      this.logger.warn('Vault client not initialized during getPrivateKey');
+
+      return null;
+    }
+
     const command = new GetSecretValueCommand({
       SecretId: `${this.prefix}${PATHS.IDENTITY_PRIVATE_KEY}`,
     });

--- a/libs/dsb-client-gateway-secrets-engine/src/lib/service/aws-secrets-manager.service.ts
+++ b/libs/dsb-client-gateway-secrets-engine/src/lib/service/aws-secrets-manager.service.ts
@@ -244,7 +244,7 @@ export class AwsSecretsManagerService
   @Span('aws_ssm_getPrivateKey')
   public async getPrivateKey(): Promise<string | null> {
     if (!this.client) {
-      this.logger.warn('Vault client not initialized during getPrivateKey');
+      this.logger.warn('AWS client not initialized during getPrivateKey');
 
       return null;
     }


### PR DESCRIPTION
This is fix an issue where the nest app calls `getPrivateKey` before the client is created in `onModuleInit`