### PR TITLE
feat(dsb-client-gateway-api): add gateway config endpoint and sync with ui

### DIFF
--- a/apps/dsb-client-gateway-api/src/app/app.module.ts
+++ b/apps/dsb-client-gateway-api/src/app/app.module.ts
@@ -21,6 +21,7 @@ import { DdhubClientGatewayTracingModule } from '@dsb-client-gateway/ddhub-clien
 import { CronModule } from './modules/cron/cron.module';
 import { StorageModule } from './modules/storage/storage.module';
 import { DdhubClientGatewayEventsModule } from '@dsb-client-gateway/ddhub-client-gateway-events';
+import { GatewayModule } from './modules/gateway/gateway.module';
 
 @Module({})
 export class AppModule {
@@ -54,6 +55,7 @@ export class AppModule {
       TopicModule,
       CronModule,
       DdhubClientGatewayEventsModule,
+      GatewayModule,
     ];
 
     const providers = [

--- a/apps/dsb-client-gateway-api/src/app/modules/gateway/dto/gateway-response.dto.ts
+++ b/apps/dsb-client-gateway-api/src/app/modules/gateway/dto/gateway-response.dto.ts
@@ -1,0 +1,11 @@
+import { GatewayConfig } from '@ddhub-client-gateway/identity/models';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GatewayResponseDto implements GatewayConfig {
+  @ApiProperty({
+    type: String,
+    description: 'Configured namespace',
+    example: 'ddhub.apps.energyweb.iam.ewc',
+  })
+  namespace: string;
+}

--- a/apps/dsb-client-gateway-api/src/app/modules/gateway/gateway.controller.ts
+++ b/apps/dsb-client-gateway-api/src/app/modules/gateway/gateway.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get, HttpStatus, UseGuards } from '@nestjs/common';
+import { DigestGuard } from '../utils/guards/digest.guard';
+import { ApiResponse, ApiTags } from '@nestjs/swagger';
+import { GatewayResponseDto } from './dto/gateway-response.dto';
+import { ConfigService } from '@nestjs/config';
+
+@Controller('gateway')
+@UseGuards(DigestGuard)
+@ApiTags('Gateway')
+export class GatewayController {
+  constructor(protected readonly configService: ConfigService) {}
+
+  @Get()
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Gateway data',
+    type: () => GatewayResponseDto,
+  })
+  @ApiResponse({
+    status: HttpStatus.UNAUTHORIZED,
+    description: 'Unauthorized',
+  })
+  public async get(): Promise<GatewayResponseDto> {
+    return {
+      namespace: this.configService.get<string>('PARENT_NAMESPACE'),
+    };
+  }
+}

--- a/apps/dsb-client-gateway-api/src/app/modules/gateway/gateway.controller.ts
+++ b/apps/dsb-client-gateway-api/src/app/modules/gateway/gateway.controller.ts
@@ -20,7 +20,7 @@ export class GatewayController {
     status: HttpStatus.UNAUTHORIZED,
     description: 'Unauthorized',
   })
-  public async get(): Promise<GatewayResponseDto> {
+  public get(): GatewayResponseDto {
     return {
       namespace: this.configService.get<string>('PARENT_NAMESPACE'),
     };

--- a/apps/dsb-client-gateway-api/src/app/modules/gateway/gateway.module.ts
+++ b/apps/dsb-client-gateway-api/src/app/modules/gateway/gateway.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { GatewayController } from './gateway.controller';
+
+@Module({
+  imports: [],
+  providers: [],
+  controllers: [GatewayController],
+  exports: [],
+})
+export class GatewayModule {}

--- a/apps/dsb-client-gateway-frontend/src/pages/_app.tsx
+++ b/apps/dsb-client-gateway-frontend/src/pages/_app.tsx
@@ -22,6 +22,7 @@ import { makeServer } from '../services/mock.service';
 import '@asyncapi/react-component/styles/default.min.css';
 import 'nprogress/nprogress.css';
 import '../styles/globals.css';
+import { useGatewayIdentityEffects } from 'libs/ddhub-client-gateway-frontend/ui/gateway-settings/src/lib/containers/GatewayIdentity/GatewayIdentity.effects';
 
 if (
   process.env.NODE_ENV !== 'production' &&
@@ -41,6 +42,7 @@ export interface MyAppProps extends AppProps {
 }
 
 function InitializeAccountStatus(props) {
+  useGatewayIdentityEffects();
   useCheckAccountStatusEffects();
   return <>{props.children}</>;
 }

--- a/libs/ddhub-client-gateway-frontend/identity/models/src/index.ts
+++ b/libs/ddhub-client-gateway-frontend/identity/models/src/index.ts
@@ -1,3 +1,4 @@
 export * from './lib/dsb-client-gateway-identity-models';
 export * from './lib/balance.enum';
 export * from './lib/identity.interface';
+export * from './lib/gateway.interface';

--- a/libs/ddhub-client-gateway-frontend/identity/models/src/lib/gateway.interface.ts
+++ b/libs/ddhub-client-gateway-frontend/identity/models/src/lib/gateway.interface.ts
@@ -1,0 +1,3 @@
+export interface GatewayConfig {
+  namespace: string;
+}

--- a/libs/ddhub-client-gateway-frontend/ui/api-hooks/src/lib/gateway/getGatewayConfig.ts
+++ b/libs/ddhub-client-gateway-frontend/ui/api-hooks/src/lib/gateway/getGatewayConfig.ts
@@ -1,0 +1,32 @@
+import { useQueryClient } from 'react-query';
+import {
+  GatewayResponseDto,
+  getGatewayControllerGetQueryKey,
+  useGatewayControllerGet,
+} from '@dsb-client-gateway/dsb-client-gateway-api-client';
+import { useCustomAlert } from '@ddhub-client-gateway-frontend/ui/core';
+
+export const useGatewayConfig = () => {
+  const Swal = useCustomAlert();
+  const queryClient = useQueryClient();
+  const cachedConfig: GatewayResponseDto | undefined = queryClient.getQueryData(
+    getGatewayControllerGetQueryKey()
+  );
+
+  const { data, isLoading } = useGatewayControllerGet({
+    query: {
+      enabled: !cachedConfig,
+      onError: (err: { message: string }) => {
+        console.error(err);
+        Swal.httpError(err);
+      },
+    },
+  });
+
+  const config = data ?? ({} as GatewayResponseDto);
+
+  return {
+    config: cachedConfig ?? config,
+    isLoading,
+  };
+};

--- a/libs/ddhub-client-gateway-frontend/ui/api-hooks/src/lib/gateway/index.ts
+++ b/libs/ddhub-client-gateway-frontend/ui/api-hooks/src/lib/gateway/index.ts
@@ -1,0 +1,1 @@
+export * from './getGatewayConfig';

--- a/libs/ddhub-client-gateway-frontend/ui/api-hooks/src/lib/index.ts
+++ b/libs/ddhub-client-gateway-frontend/ui/api-hooks/src/lib/index.ts
@@ -5,3 +5,4 @@ export * from './channels';
 export * from './messaging';
 export * from './settings';
 export * from './scheduler';
+export * from './gateway';

--- a/libs/ddhub-client-gateway-frontend/ui/gateway-settings/src/lib/containers/GatewayIdentity/GatewayIdentity.effects.ts
+++ b/libs/ddhub-client-gateway-frontend/ui/gateway-settings/src/lib/containers/GatewayIdentity/GatewayIdentity.effects.ts
@@ -1,15 +1,19 @@
 import { useCustomAlert } from '@ddhub-client-gateway-frontend/ui/core';
-import { useIdentity } from '@ddhub-client-gateway-frontend/ui/api-hooks';
+import {
+  useIdentity,
+  useGatewayConfig,
+} from '@ddhub-client-gateway-frontend/ui/api-hooks';
 import { useSetUserDataEffect } from '@ddhub-client-gateway-frontend/ui/login';
 
 export const useGatewayIdentityEffects = () => {
   const { identity } = useIdentity();
+  const { config } = useGatewayConfig();
   const { setUserData } = useSetUserDataEffect();
   const Swal = useCustomAlert();
 
-  const namespace =
-    process.env['NEXT_PUBLIC_PARENT_NAMESPACE'] ??
-    'ddhub.apps.energyweb.iam.ewc';
+  console.log(config);
+
+  const namespace = config?.namespace ?? 'ddhub.apps.energyweb.iam.ewc';
 
   const update = async () => {
     const result = await Swal.warning({

--- a/libs/ddhub-client-gateway-frontend/ui/gateway-settings/src/lib/containers/GatewayIdentity/GatewayIdentity.effects.ts
+++ b/libs/ddhub-client-gateway-frontend/ui/gateway-settings/src/lib/containers/GatewayIdentity/GatewayIdentity.effects.ts
@@ -11,8 +11,6 @@ export const useGatewayIdentityEffects = () => {
   const { setUserData } = useSetUserDataEffect();
   const Swal = useCustomAlert();
 
-  console.log(config);
-
   const namespace = config?.namespace ?? 'ddhub.apps.energyweb.iam.ewc';
 
   const update = async () => {

--- a/libs/ddhub-client-gateway-frontend/ui/login/src/lib/LoadingInfo/LoadingInfo.tsx
+++ b/libs/ddhub-client-gateway-frontend/ui/login/src/lib/LoadingInfo/LoadingInfo.tsx
@@ -1,13 +1,14 @@
-import { CircularProgress, Stack, Typography } from '@mui/material';
+import { CircularProgress, Stack } from '@mui/material';
 import { makeStyles } from 'tss-react/mui';
 
 export interface LoadingInfoProps {
   children: React.ReactNode;
+  mt?: number;
 }
 
 export function LoadingInfo(props: LoadingInfoProps) {
   return (
-    <Stack spacing={1} direction={'row'}>
+    <Stack spacing={1} direction={'row'} mt={props?.mt ?? 0}>
       <CircularProgress color="primary" size={22} />
       <Stack>{props.children}</Stack>
     </Stack>

--- a/libs/ddhub-client-gateway-frontend/ui/login/src/lib/LoginStatus/LoginStatus.effects.tsx
+++ b/libs/ddhub-client-gateway-frontend/ui/login/src/lib/LoginStatus/LoginStatus.effects.tsx
@@ -20,7 +20,7 @@ export const useLoginStatusEffects = () => {
   };
 
   const checkingIdentity = () => (
-    <LoadingInfo>
+    <LoadingInfo mt={2}>
       <Stack spacing={1}>
         <Typography variant="body1">Checking identity</Typography>
         <Typography variant="body2">This might take a while.</Typography>

--- a/libs/ddhub-client-gateway-frontend/ui/login/src/lib/SetUserData.effects.ts
+++ b/libs/ddhub-client-gateway-frontend/ui/login/src/lib/SetUserData.effects.ts
@@ -4,6 +4,7 @@ import {
 } from './check-account-status/CheckAccountStatus';
 import { getIdentityControllerGetQueryKey } from '@dsb-client-gateway/dsb-client-gateway-api-client';
 import {
+  GatewayConfig,
   IdentityWithEnrolment,
   Role,
   RoleStatus,
@@ -18,6 +19,7 @@ import {
   IndexableRouteRestrictions,
 } from './config/route-restrictions.interface';
 import { useCustomAlert } from '@ddhub-client-gateway-frontend/ui/core';
+import { useGatewayConfig } from '@ddhub-client-gateway-frontend/ui/api-hooks';
 
 export const routeRestrictions = new Map<string, string>()
   .set('topicManagement', routerConst.TopicManagement)
@@ -30,7 +32,8 @@ export const routeRestrictions = new Map<string, string>()
 
 export const getRoutesToDisplay = (
   accountRoles: Role[],
-  restrictions: IndexableRouteRestrictions
+  restrictions: IndexableRouteRestrictions,
+  config: GatewayConfig
 ): Set<string> => {
   if (!accountRoles) {
     return new Set();
@@ -40,8 +43,7 @@ export const getRoutesToDisplay = (
       (role) =>
         role.status === RoleStatus.SYNCED &&
         role.namespace.includes(
-          process.env['NEXT_PUBLIC_PARENT_NAMESPACE'] ??
-            'ddhub.apps.energyweb.iam.ewc'
+          config?.namespace ?? 'ddhub.apps.energyweb.iam.ewc'
         )
     )
     .map((role) => role.namespace);
@@ -67,6 +69,7 @@ export const getRoutesToDisplay = (
 export const useSetUserDataEffect = () => {
   const Swal = useCustomAlert();
   const router = useRouter();
+  const { config } = useGatewayConfig();
   const { userData, setUserData } = useContext(UserDataContext);
   const queryClient = useQueryClient();
 
@@ -85,7 +88,8 @@ export const useSetUserDataEffect = () => {
     if (res?.enrolment?.roles) {
       const displayedRoutes = getRoutesToDisplay(
         res.enrolment.roles,
-        routeRestrictions as unknown as IndexableRouteRestrictions
+        routeRestrictions as unknown as IndexableRouteRestrictions,
+        config
       );
 
       setUserData({


### PR DESCRIPTION
https://energyweb.atlassian.net/browse/AEMO-478

Scope:
1. Create `GET /gateway` endpoint to return `PARENT_NAMESPACE` env var to UI.
2. In the UI, replace instances of `NEXT_PUBLIC_PARENT_NAMESPACE` to retrieved value from `GET /gateway`.