### PR TITLE
fix: login navigation

### DIFF
--- a/libs/ddhub-client-gateway-frontend/identity/models/src/lib/dsb-client-gateway-identity-models.ts
+++ b/libs/ddhub-client-gateway-frontend/identity/models/src/lib/dsb-client-gateway-identity-models.ts
@@ -38,6 +38,6 @@ export interface Role {
 }
 
 export interface Enrolment {
-  did: string | null;
+  did?: string;
   roles: Role[];
 }

--- a/libs/ddhub-client-gateway-frontend/ui/gateway-settings/src/lib/containers/GatewayIdentity/GatewayIdentity.effects.ts
+++ b/libs/ddhub-client-gateway-frontend/ui/gateway-settings/src/lib/containers/GatewayIdentity/GatewayIdentity.effects.ts
@@ -6,9 +6,8 @@ import {
 import { useSetUserDataEffect } from '@ddhub-client-gateway-frontend/ui/login';
 
 export const useGatewayIdentityEffects = () => {
-  const { identity } = useIdentity();
   const { config } = useGatewayConfig();
-  const { setUserData } = useSetUserDataEffect();
+  const { userData, setUserData } = useSetUserDataEffect();
   const Swal = useCustomAlert();
 
   const namespace = config?.namespace ?? 'ddhub.apps.energyweb.iam.ewc';
@@ -26,7 +25,7 @@ export const useGatewayIdentityEffects = () => {
 
   return {
     update,
-    identity,
+    identity: { enrolment: { did: userData.did } },
     namespace,
   };
 };

--- a/libs/ddhub-client-gateway-frontend/ui/login/src/lib/LoginStatus/IdentitySuccessful/IdentitySuccessful.tsx
+++ b/libs/ddhub-client-gateway-frontend/ui/login/src/lib/LoginStatus/IdentitySuccessful/IdentitySuccessful.tsx
@@ -12,7 +12,7 @@ export interface IdentitySuccessfulProps {
 export const IdentitySuccessful = (props: IdentitySuccessfulProps) => {
   const router = useRouter();
   const { classes } = useStyles();
-  const { totalSeconds } = useCountdown(10 * 1000, () => {
+  const { totalSeconds } = useCountdown(60 * 10 * 1000, () => {
     navigate();
   });
 
@@ -23,7 +23,7 @@ export const IdentitySuccessful = (props: IdentitySuccessfulProps) => {
   return (
     <Stack spacing={4} mt={2}>
       <Stack spacing={1} alignItems="top" direction="row">
-        <Check color="success" size={22} />
+        <Check className={classes.icon} size={22} />
         <Stack spacing={1}>
           <Typography variant="body1">Identity check is successful</Typography>
           <Typography variant="body2" className={classes.role}>
@@ -53,6 +53,9 @@ export default IdentitySuccessful;
 export const useStyles = makeStyles()((theme) => ({
   role: {
     color: theme.palette.primary.main,
+  },
+  icon: {
+    color: theme.palette.success.main,
   },
   submitBtn: {
     textTransform: 'none',

--- a/libs/ddhub-client-gateway-frontend/ui/login/src/lib/LoginStatus/IdentitySuccessful/IdentitySuccessful.tsx
+++ b/libs/ddhub-client-gateway-frontend/ui/login/src/lib/LoginStatus/IdentitySuccessful/IdentitySuccessful.tsx
@@ -4,21 +4,32 @@ import { Check } from 'react-feather';
 import { useRouter } from 'next/router';
 import { routerConst } from '@ddhub-client-gateway-frontend/ui/utils';
 import { useCountdown } from '../Countdown.effects';
+import LoadingInfo from '../../LoadingInfo/LoadingInfo';
 
 export interface IdentitySuccessfulProps {
   children?: React.ReactNode;
+  isFirstLogin?: boolean;
 }
 
 export const IdentitySuccessful = (props: IdentitySuccessfulProps) => {
   const router = useRouter();
   const { classes } = useStyles();
-  const { totalSeconds } = useCountdown(60 * 10 * 1000, () => {
+  const { totalSeconds } = useCountdown(10 * 1000, () => {
     navigate();
   });
 
   const navigate = () => {
-    return router.push(routerConst.IntegrationAPIs);
+    return router.push(routerConst.Dashboard);
   };
+
+  if (!props.isFirstLogin) {
+    navigate();
+    return (
+      <LoadingInfo mt={2}>
+        <Typography>Redirecting...</Typography>
+      </LoadingInfo>
+    );
+  }
 
   return (
     <Stack spacing={4} mt={2}>

--- a/libs/ddhub-client-gateway-frontend/ui/login/src/lib/LoginStatus/LoginStatus.effects.tsx
+++ b/libs/ddhub-client-gateway-frontend/ui/login/src/lib/LoginStatus/LoginStatus.effects.tsx
@@ -10,8 +10,10 @@ import IdentitySuccessful from './IdentitySuccessful/IdentitySuccessful';
 import ResetPrivateKey from '../ResetPrivateKey/ResetPrivateKey';
 import LoadingInfo from '../LoadingInfo/LoadingInfo';
 import { Stack, Typography } from '@mui/material';
+import { useEffect, useState } from 'react';
 
 export const useLoginStatusEffects = () => {
+  const [isFirstLogin, setIsFirstLogin] = useState(false);
   const { isLoading, submit, status, errorMessage, userData } =
     usePrivateKeyEffects();
 
@@ -28,14 +30,26 @@ export const useLoginStatusEffects = () => {
     </LoadingInfo>
   );
 
+  const showLoginForm = () => {
+    if (isLoading) {
+      return checkingIdentity();
+    } else {
+      return <LoginForm onPrivateKeySubmit={privateKeyHandler} />;
+    }
+  };
+
+  useEffect(() => {
+    if (status === AccountStatusEnum.FirstLogin) {
+      setIsFirstLogin(true);
+    }
+  }, [status]);
+
   const statusFactory = () => {
     switch (status) {
+      case AccountStatusEnum.FirstLogin:
+        return showLoginForm();
       case AccountStatusEnum.NotSetPrivateKey:
-        if (isLoading) {
-          return checkingIdentity();
-        } else {
-          return <LoginForm onPrivateKeySubmit={privateKeyHandler} />;
-        }
+        return showLoginForm();
       case AccountStatusEnum.ErrorOccur:
         return (
           <>
@@ -58,7 +72,7 @@ export const useLoginStatusEffects = () => {
           return checkingIdentity();
         } else {
           return (
-            <IdentitySuccessful>
+            <IdentitySuccessful isFirstLogin={isFirstLogin}>
               {
                 userData.roles
                   .filter((role) => role.required)

--- a/libs/ddhub-client-gateway-frontend/ui/login/src/lib/LoginStatus/RequestApproved/RequestApproved.tsx
+++ b/libs/ddhub-client-gateway-frontend/ui/login/src/lib/LoginStatus/RequestApproved/RequestApproved.tsx
@@ -2,12 +2,15 @@ import { Typography, Stack, Box } from '@mui/material';
 import { Check } from 'react-feather';
 import RefreshAccountStatus from '../RefreshAccountStatus/RefreshAccountStatus';
 import ResetPrivateKey from '../../ResetPrivateKey/ResetPrivateKey';
+import { makeStyles } from 'tss-react/mui';
 
 export const RequestApproved = () => {
+  const { classes } = useStyles();
+
   return (
     <Stack spacing={4} mt={2}>
       <Stack spacing={1} direction="row">
-        <Check color="success" size={22} />
+        <Check className={classes.icon} size={22} />
         <Stack>
           <Typography variant="body1">Enrolment request approved</Typography>
           <Typography variant="body2">
@@ -24,3 +27,9 @@ export const RequestApproved = () => {
 };
 
 export default RequestApproved;
+
+export const useStyles = makeStyles()((theme) => ({
+  icon: {
+    color: theme.palette.success.main,
+  },
+}));

--- a/libs/ddhub-client-gateway-frontend/ui/login/src/lib/SetUserData.effects.ts
+++ b/libs/ddhub-client-gateway-frontend/ui/login/src/lib/SetUserData.effects.ts
@@ -99,6 +99,7 @@ export const useSetUserDataEffect = () => {
         isChecking: false,
         routeRestrictions,
         displayedRoutes,
+        did: res.enrolment.did,
       });
     } else {
       setUserData({

--- a/libs/ddhub-client-gateway-frontend/ui/login/src/lib/UserDataContext.ts
+++ b/libs/ddhub-client-gateway-frontend/ui/login/src/lib/UserDataContext.ts
@@ -10,6 +10,7 @@ export interface UserDataContext {
   routeRestrictions: RouteRestrictions;
   displayedRoutes: Set<string>;
   roles: Role[];
+  did?: string;
 }
 
 const initialData = {

--- a/libs/ddhub-client-gateway-frontend/ui/login/src/lib/check-account-status/CheckAccountStatus.effects.ts
+++ b/libs/ddhub-client-gateway-frontend/ui/login/src/lib/check-account-status/CheckAccountStatus.effects.ts
@@ -15,7 +15,7 @@ export const useCheckAccountStatusEffects = (
   withBackdrop = true
 ) => {
   const queryClient = useQueryClient();
-  const { setUserData, setIsChecking, setDataOnError } = useSetUserDataEffect();
+  const { setUserData, setIsChecking } = useSetUserDataEffect();
   const { setIsLoading } = useBackdropContext();
   const [checking, setChecking] = useState(triggerQuery);
 
@@ -35,7 +35,6 @@ export const useCheckAccountStatusEffects = (
       );
       return { identityData, routeRestrictions };
     } catch (e: any) {
-      setDataOnError(e, false);
       return e;
     }
   };

--- a/libs/ddhub-client-gateway-frontend/ui/login/src/lib/check-account-status/CheckAccountStatus.tsx
+++ b/libs/ddhub-client-gateway-frontend/ui/login/src/lib/check-account-status/CheckAccountStatus.tsx
@@ -8,14 +8,16 @@ export enum AccountStatusEnum {
   InsufficientFund = 'Insufficient fund',
   NotSetPrivateKey = 'Not Set Private Key',
   ErrorOccur = 'Error Occur',
+  FirstLogin = 'First Login',
 }
 
 export const checkAccountStatus = (
   res: IdentityWithEnrolment
 ): AccountStatusEnum | RoleStatus => {
   if (!res) {
-    return AccountStatusEnum.NotSetPrivateKey;
+    return AccountStatusEnum.FirstLogin;
   }
+
   if (isBalanceTooLow(res.balance)) {
     return AccountStatusEnum.InsufficientFund;
   }


### PR DESCRIPTION
**Issue:** Navigation countdown was incorrectly shown every time UI was refreshed.
Changes:
1. First login flag is set if no private key is set on refresh.
2. First login/enrolment flow stays the same.
3. Subsequent refreshes will redirect to dashboard.
4. Did stored in `userData` for easy access