### PR TITLE
fix(dsb-client-gateway-api): adding decorator to identity claim resp

### DIFF
--- a/apps/dsb-client-gateway-api/src/app/modules/identity/dto/claims-response.dto.ts
+++ b/apps/dsb-client-gateway-api/src/app/modules/identity/dto/claims-response.dto.ts
@@ -1,12 +1,40 @@
 import { RoleStatus } from '@ddhub-client-gateway/identity/models';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class ClaimResponseDto {
+  @ApiProperty({
+    type: String,
+    description: 'Namespace',
+    example: 'user.roles.ddhub.apps.szostak.iam.ewc',
+  })
   namespace: string;
+
+  @ApiProperty({
+    enum: RoleStatus,
+    description: 'Role status',
+    example: RoleStatus.APPROVED,
+  })
   status: RoleStatus;
+
+  @ApiProperty({
+    type: Boolean,
+    description: 'Role enrolment status on DID document',
+    example: true,
+  })
   syncedToDidDoc: boolean;
 }
 
 export class ClaimsResponseDto {
+  @ApiProperty({
+    type: String,
+    description: 'DID address',
+    example: 'did:ethr:volta:0xfeFBb03EFc1054Cc4e3Fbf36362689cc1F5924a8',
+  })
   did: string;
+
+  @ApiProperty({
+    description: 'Array of claims',
+    type: () => [ClaimResponseDto],
+  })
   claims: ClaimResponseDto[];
 }

--- a/apps/dsb-client-gateway-api/src/app/modules/message/dto/response/get-message-response.dto.ts
+++ b/apps/dsb-client-gateway-api/src/app/modules/message/dto/response/get-message-response.dto.ts
@@ -101,7 +101,7 @@ export class GetMessagesResponseDto {
 
   @IsEnum(EncryptionStatus)
   @ApiProperty({
-    description: 'Encryption status for a message',
+    description: 'Signature validation status for a message',
     enum: [
       EncryptionStatus.FAILED,
       EncryptionStatus.NOT_PERFORMED,


### PR DESCRIPTION
adding ApiProperty decorator for OpenApi spec generation
updating /messages `signatureValid` description