### PR TITLE
fix(dsb-client-gateway-api): allow gbc to collect ajv

### DIFF
--- a/apps/dsb-client-gateway-api/src/app/modules/message/service/message.service.ts
+++ b/apps/dsb-client-gateway-api/src/app/modules/message/service/message.service.ts
@@ -181,7 +181,7 @@ export class MessageService {
 
     for (const res of result.status) {
       for (const detail of res.details) {
-        this.logger.log(
+        messageLoggerContext.log(
           `message sent with id ${detail.messageId} to ${detail.did} with status code ${detail.statusCode}`
         );
       }

--- a/apps/dsb-client-gateway-api/src/app/modules/utils/validator/decorators/IsSchemaValid.ts
+++ b/apps/dsb-client-gateway-api/src/app/modules/utils/validator/decorators/IsSchemaValid.ts
@@ -4,33 +4,6 @@ import { SchemaType } from '../../../message/message.const';
 import addFormats from 'ajv-formats';
 import { MalformedJSONException } from '../../../message/exceptions/malformed-json.exception';
 
-const ajv = new Ajv({ allErrors: true, multipleOfPrecision: 1 });
-addFormats(ajv, {
-  mode: 'fast',
-  formats: [
-    'date',
-    'time',
-    'date-time',
-    'duration',
-    'uri',
-    'uri-reference',
-    'uri-template',
-    'email',
-    'hostname',
-    'ipv4',
-    'ipv6',
-    'uuid',
-    'json-pointer',
-    'byte',
-    'int32',
-    'int64',
-    'float',
-    'double',
-    'password',
-    'binary',
-  ],
-  keywords: true,
-});
 export function IsSchemaValid(
   schemaType: string,
   schema: object,
@@ -46,6 +19,35 @@ export function IsSchemaValid(
 }
 
 function validateJSONSchema(schema: object, payload: string) {
+  const ajv = new Ajv({ allErrors: true, multipleOfPrecision: 1 });
+
+  addFormats(ajv, {
+    mode: 'fast',
+    formats: [
+      'date',
+      'time',
+      'date-time',
+      'duration',
+      'uri',
+      'uri-reference',
+      'uri-template',
+      'email',
+      'hostname',
+      'ipv4',
+      'ipv6',
+      'uuid',
+      'json-pointer',
+      'byte',
+      'int32',
+      'int64',
+      'float',
+      'double',
+      'password',
+      'binary',
+    ],
+    keywords: true,
+  });
+
   let validate;
   let jsonPayload: object;
   try {

--- a/apps/dsb-client-gateway-api/tsconfig.app.json
+++ b/apps/dsb-client-gateway-api/tsconfig.app.json
@@ -5,7 +5,8 @@
     "module": "commonjs",
     "types": ["node"],
     "emitDecoratorMetadata": true,
-    "target": "es2015"
+    "target": "es2015",
+    "removeComments": true
   },
   "exclude": ["**/*.spec.ts", "**/*.test.ts"],
   "include": [

--- a/libs/ddhub-client-gateway-message-broker/src/lib/services/ddhub-base.service.ts
+++ b/libs/ddhub-client-gateway-message-broker/src/lib/services/ddhub-base.service.ts
@@ -20,7 +20,7 @@ export abstract class DdhubBaseService {
     protected readonly retryConfigService: RetryConfigService,
     protected readonly ddhubLoginService: DdhubLoginService,
     protected readonly tlsAgentService: TlsAgentService
-  ) { }
+  ) {}
 
   protected async request<T>(
     requestFn: () => Observable<AxiosResponse<T>>,
@@ -54,7 +54,7 @@ export abstract class DdhubBaseService {
       ...options,
     };
 
-    if (e.errno === -3001) {
+    if (e.errno === -3001 || e.errno === -113) {
       this.logger.error('incorrect network activity');
       this.logger.error(e);
 


### PR DESCRIPTION
ajv.compile was causing memory leak due to bug/incorrect usage (constant compile calls instead of caching), it was creating schema for each call without clearing it