### PR TITLE
fix(ddhub-client-gateway-ui-messaging): display boolean values in entry view

### DIFF
--- a/libs/ddhub-client-gateway-frontend/ui/messaging/src/lib/containers/modals/MessageInboxDetails/MessageInboxDetails.effects.ts
+++ b/libs/ddhub-client-gateway-frontend/ui/messaging/src/lib/containers/modals/MessageInboxDetails/MessageInboxDetails.effects.ts
@@ -52,7 +52,7 @@ export const useMessageInboxDetailsEffects = () => {
     const parsedArrayItem: any[] = [];
 
     Object.entries(parsed).forEach(([name, value]) => {
-      const validValue = typeof value === 'string' || typeof value === 'number';
+      const validValue = typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
       const valueArray = isObject(value) ? value : [];
       const formattedKey = camelToFlat(name);
 


### PR DESCRIPTION
Important: default value should be set in JSON schema for this to display correctly - undefined values are stripped from JSON schema and the value is not true or false until the checkbox is interacted with.