### PR TITLE
fix(dsb-client-gateway-api): fix api/user auth guards

### DIFF
--- a/libs/ddhub-client-gateway-guard/src/lib/guard/api-key.guard.ts
+++ b/libs/ddhub-client-gateway-guard/src/lib/guard/api-key.guard.ts
@@ -70,8 +70,9 @@ export class ApiKeyGuard implements CanActivate {
 
     const apiKeyFromHeaders: string | undefined = headers['x-api-key'];
 
-    if (apiKeyFromHeaders) {
-      return apiKeyFromHeaders === apiKey;
+    if (apiKeyFromHeaders && apiKeyFromHeaders === apiKey) {
+      request.user = 'api-key';
+      return true;
     }
 
     const usernameFromHeaders: string | undefined = headers['x-api-username'];

--- a/libs/ddhub-client-gateway-user-roles/src/lib/guard/user.guard.ts
+++ b/libs/ddhub-client-gateway-user-roles/src/lib/guard/user.guard.ts
@@ -36,6 +36,10 @@ export class UserGuard implements CanActivate {
       return true;
     }
 
+    if (request.user === 'api-key') {
+      return true;
+    }
+
     const excludedRoute: boolean = this.reflector.get<boolean>(
       EXCLUDED_ROUTE,
       context.getHandler()


### PR DESCRIPTION
Changes:
- When API Key and User Auth are both enabled, prioritise api key auth if provided and successfully passes `ApiKeyGuard.canActivate`