### PR TITLE
Fix/date time fixes

### DIFF
--- a/apps/dsb-client-gateway-api/src/app/modules/message/gateway/events.gateway.ts
+++ b/apps/dsb-client-gateway-api/src/app/modules/message/gateway/events.gateway.ts
@@ -78,7 +78,9 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayInit {
         client.request.url.split('?')[1]
       ).get('clientId');
 
-      if (_clientId === null) {
+      const clientIdTrim = _clientId?.trim();
+
+      if (!clientIdTrim) {
         this.logger.warn(
           `required parameter 'clientId' not specified, dropping connection`
         );
@@ -91,7 +93,7 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayInit {
       }
 
       const clientIdRegex = new RegExp(/^[a-zA-Z0-9]+$/);
-      if (!clientIdRegex.test(_clientId)) {
+      if (!clientIdRegex.test(clientIdTrim)) {
         this.logger.warn(
           `Required paramater 'clientId' with format Alphanumeric string`
         );
@@ -103,8 +105,8 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayInit {
         return;
       }
 
-      await this.clientsService.attemptCreateClient(_clientId).catch((e) => {
-        this.logger.error(`failed to use client ${_clientId}`);
+      await this.clientsService.attemptCreateClient(clientIdTrim).catch((e) => {
+        this.logger.error(`failed to use client ${clientIdTrim}`);
 
         client.close(
           1000,
@@ -136,7 +138,7 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayInit {
       }
 
       this.logger.log(
-        `New client connected ${_clientId}, total client connected ${this.server.clients.size}`
+        `New client connected ${clientIdTrim}, total client connected ${this.server.clients.size}`
       );
     } catch (e) {
       this.logger.error(`unexpected websocket error`);

--- a/apps/dsb-client-gateway-api/src/app/modules/utils/validator/decorators/IsSchemaValid.ts
+++ b/apps/dsb-client-gateway-api/src/app/modules/utils/validator/decorators/IsSchemaValid.ts
@@ -40,12 +40,8 @@ function validateJSONSchema(schema: object, payload: string) {
       'uuid',
       'json-pointer',
       'byte',
-      'int32',
-      'int64',
       'float',
       'double',
-      'password',
-      'binary',
     ],
     keywords: true,
   });

--- a/libs/ddhub-client-gateway-frontend/ui/core/src/components/JsonSchemaForm/form/Form.tsx
+++ b/libs/ddhub-client-gateway-frontend/ui/core/src/components/JsonSchemaForm/form/Form.tsx
@@ -8,6 +8,7 @@ import {
   RadioWidget,
   SelectWidget,
   CheckboxWidget,
+  TimeWidget,
 } from '../widgets';
 import {
   CustomArrayFieldItemTemplate,
@@ -41,6 +42,7 @@ const customWidgets: RegistryWidgetsType = {
   SelectWidget: SelectWidget,
   DateWidget: DateTimeWidget,
   DateTimeWidget: DateTimeWidget,
+  TimeWidget: TimeWidget,
 };
 
 const customFormats = {

--- a/libs/ddhub-client-gateway-frontend/ui/core/src/components/JsonSchemaForm/form/Form.tsx
+++ b/libs/ddhub-client-gateway-frontend/ui/core/src/components/JsonSchemaForm/form/Form.tsx
@@ -39,6 +39,8 @@ const customWidgets: RegistryWidgetsType = {
   RadioWidget: RadioWidget,
   CheckboxesWidget: CheckboxesWidget,
   SelectWidget: SelectWidget,
+  DateWidget: DateTimeWidget,
+  DateTimeWidget: DateTimeWidget,
 };
 
 const customFormats = {

--- a/libs/ddhub-client-gateway-frontend/ui/core/src/components/JsonSchemaForm/widgets/DateTimeWidget.tsx
+++ b/libs/ddhub-client-gateway-frontend/ui/core/src/components/JsonSchemaForm/widgets/DateTimeWidget.tsx
@@ -1,116 +1,129 @@
 import { WidgetProps } from '@rjsf/utils';
 import {
-  DateOrTimeView,
-  DateTimePickerToolbar,
-  DateTimeValidationError,
   DesktopDateTimePicker,
+  DesktopDatePicker,
   LocalizationProvider,
   PickerChangeHandlerContext,
+  DateTimeValidationError,
+  PickersActionBarAction,
+  DateOrTimeView
 } from '@mui/x-date-pickers';
 import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
 import { Box, InputLabel } from '@mui/material';
 import { useStyles } from '../../form/FormInput/FormInput.styles';
-import { DateTime } from 'luxon';
 import { DateTimeIcon } from '../../icons';
+import { DateTime } from 'luxon';
 
-const defaultFormat = 'dd/MM/yyyy HH:mm:ss';
-const defaultViews: DateOrTimeView[] = [
-  'year',
-  'month',
-  'day',
-  'hours',
-  'minutes',
-  'seconds',
-];
+const defaultFormat = 'yyyy-MM-dd HH:mm:ss';
+const dateFormat = 'yyyy-MM-dd';
+
 export const DateTimeWidget = (props: WidgetProps) => {
   const { theme, classes } = useStyles();
-  const { label, onChange, value, options } = props;
+  const { label, value, onChange, schema, options } = props;
+  const isDateOnly = schema.format === 'date';
+  const isLocalDateTime = schema.format === 'local-date-time';
   const withSeconds = options['withSeconds'] === false ? false : true;
+  const datetimeFormat = !withSeconds ? 'yyyy-MM-dd HH:mm' : defaultFormat;
+
+  const defaultViews: DateOrTimeView[] = [
+    'year',
+    'month',
+    'day',
+    'hours',
+    'minutes',
+    'seconds',
+  ];
 
   const views = !withSeconds
-    ? defaultViews.slice(0, defaultViews.length - 1)
-    : defaultViews;
-  const format = !withSeconds ? 'dd/MM/yyyy HH:mm' : defaultFormat;
+  ? defaultViews.slice(0, defaultViews.length - 1)
+  : defaultViews;
+
   const formatDateTimeToISO = (value: DateTime | null) => {
     if (DateTime.isDateTime(value)) {
-      if (!withSeconds) {
-        return value.startOf('minute').toISO();
-      } else {
-        return value.startOf('second').toISO();
+      if (isDateOnly) {
+        return value.toISODate();
       }
+
+      const dateTime = withSeconds ? value.startOf('second') : value.startOf('minute');
+
+      return isLocalDateTime ? dateTime.startOf('minute').toISO() : dateTime.startOf('second').toUTC().toISO();
     }
     return null;
   };
+
   const buildDateTimeFromISO = (value: string | null) => {
     if (value) {
-      const dateTime = DateTime.fromISO(value);
+      if (isDateOnly) {
+        const dateOnly = DateTime.fromISO(value);
+        return dateOnly.isValid ? dateOnly : null;
+      }
+
+      const dateTime = isLocalDateTime ? DateTime.fromISO(value) : DateTime.fromISO(value, { zone: 'utc' });
       if (dateTime.isValid) {
-        if (!withSeconds) {
-          return dateTime.startOf('minute');
-        } else {
-          return dateTime.startOf('second');
-        }
+        return withSeconds ? dateTime.startOf('second') : dateTime.startOf('minute');
       }
     }
     return null;
   };
+
+  const commonProps = {
+    onChange: (
+      value: DateTime | null,
+      context: PickerChangeHandlerContext<DateTimeValidationError>
+    ) => {
+      if (!context.validationError) {
+        onChange(formatDateTimeToISO(value));
+      }
+    },
+    onAccept: (value: DateTime | null) => {
+      onChange(formatDateTimeToISO(value));
+    },
+    timezone: "system",
+    format: isDateOnly ? dateFormat : datetimeFormat,
+    orientation: "portrait",
+    slots: {
+      openPickerIcon: () => <DateTimeIcon />,
+    },
+    value: buildDateTimeFromISO(value),
+    slotProps: {
+      textField: { classes: { root: classes.root } },
+      nextIconButton: { sx: { color: 'white' } },
+      previousIconButton: { sx: { color: 'white' } },
+      switchViewButton: { sx: { color: 'white' } },
+      actionBar: {
+        actions: ['today', 'clear'] as PickersActionBarAction[],
+        sx: { justifyContent: 'flex-end' },
+      },
+      toolbar: {
+        toolbarFormat: dateFormat,
+        hidden: !isLocalDateTime,
+      },
+      openPickerButton: {
+        sx: {
+          mr: 1,
+          color: theme.palette.primary.main,
+        },
+      },
+    },
+  } as const;
 
   return (
     <Box>
       {label && <InputLabel className={classes.label}>{label}</InputLabel>}
       <LocalizationProvider dateAdapter={AdapterLuxon}>
-        <DesktopDateTimePicker
-          onChange={(
-            value: DateTime | null,
-            context: PickerChangeHandlerContext<DateTimeValidationError>
-          ) => {
-            if (!context.validationError) {
-              onChange(formatDateTimeToISO(value));
-            }
-          }}
-          onAccept={(value: DateTime | null) => {
-            onChange(formatDateTimeToISO(value));
-          }}
-          timezone="system"
-          value={buildDateTimeFromISO(value)}
-          ampm={false}
-          format={format}
-          orientation="portrait"
-          onOpen={() => {
-            if (!value) {
-              onChange(formatDateTimeToISO(DateTime.local()));
-            }
-          }}
-          timeSteps={{
-            seconds: 1,
-            minutes: 1,
-          }}
-          views={views}
-          slots={{
-            openPickerIcon: () => <DateTimeIcon />,
-            toolbar: DateTimePickerToolbar,
-          }}
-          slotProps={{
-            textField: { classes: { root: classes.root } },
-            nextIconButton: { sx: { color: 'white' } },
-            previousIconButton: { sx: { color: 'white' } },
-            switchViewButton: { sx: { color: 'white' } },
-            actionBar: {
-              actions: ['today', 'clear'],
-              sx: { justifyContent: 'flex-end' },
-            },
-            toolbar: {
-              toolbarFormat: 'dd/MM/yyyy',
-              hidden: false,
-            },
-            openPickerButton: {
-              sx: {
-                mr: 1,
-                color: theme.palette.primary.main,
-              },
-            },
-          }}
-        />
+        {isDateOnly ? (
+          <DesktopDatePicker {...commonProps} />
+        ) : (
+          <DesktopDateTimePicker
+            {...commonProps}
+            timeSteps={{
+              seconds: 1,
+              minutes: 1,
+            }}
+            ampm={false}
+            views={views}
+          />
+        )}
       </LocalizationProvider>
     </Box>
   );

--- a/libs/ddhub-client-gateway-frontend/ui/core/src/components/JsonSchemaForm/widgets/TimeWidget.tsx
+++ b/libs/ddhub-client-gateway-frontend/ui/core/src/components/JsonSchemaForm/widgets/TimeWidget.tsx
@@ -1,0 +1,76 @@
+import { WidgetProps } from '@rjsf/utils';
+import { DesktopTimePicker, PickerChangeHandlerContext, DateTimeValidationError } from '@mui/x-date-pickers';
+import { Box, InputLabel } from '@mui/material';
+import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { useStyles } from '../../form/FormInput/FormInput.styles';
+import { DateTime } from 'luxon';
+
+export const TimeWidget = (props: WidgetProps) => {
+  const { theme, classes } = useStyles();
+  const { label, value, onChange } = props;
+
+  const formatTime = (value: DateTime | null) => {
+    if (DateTime.isDateTime(value)) {
+      return value.toFormat('HH:mm:ssZ');
+    }
+    return null;
+  };
+
+  const buildTime = (value: string | null) => {
+    if (value) {
+      // Try parsing as ISO first
+      let dateTime = DateTime.fromISO(value);
+      if (!dateTime.isValid) {
+        // If not valid ISO, try parsing as HH:mm:ssZ
+        dateTime = DateTime.fromFormat(value, 'HH:mm:ssZ');
+      }
+      if (dateTime.isValid) {
+        return DateTime.fromObject({
+          hour: dateTime.hour,
+          minute: dateTime.minute,
+          second: dateTime.second
+        });
+      }
+    }
+    return null;
+  };
+
+  return (
+    <Box>
+      {label && <InputLabel className={classes.label}>{label}</InputLabel>}
+      <LocalizationProvider dateAdapter={AdapterLuxon}>
+        <DesktopTimePicker
+          onChange={(
+            value: DateTime | null,
+            context: PickerChangeHandlerContext<DateTimeValidationError>
+          ) => {
+            if (!context.validationError) {
+              onChange(formatTime(value));
+            }
+          }}
+          onAccept={(value: DateTime | null) => {
+            onChange(formatTime(value));
+          }}
+          views={['hours', 'minutes', 'seconds']}
+          format="HH:mm:ss"
+          timeSteps={{
+            seconds: 1,
+            minutes: 1,
+          }}
+          ampm={false}
+          value={buildTime(value)}
+          slotProps={{
+            textField: { classes: { root: classes.root } },
+            openPickerButton: {
+              sx: {
+                mr: 1,
+                color: theme.palette.primary.main,
+              },
+            },
+          }}
+        />
+      </LocalizationProvider>
+    </Box>
+  );
+};

--- a/libs/ddhub-client-gateway-frontend/ui/core/src/components/JsonSchemaForm/widgets/TimeWidget.tsx
+++ b/libs/ddhub-client-gateway-frontend/ui/core/src/components/JsonSchemaForm/widgets/TimeWidget.tsx
@@ -12,7 +12,7 @@ export const TimeWidget = (props: WidgetProps) => {
 
   const formatTime = (value: DateTime | null) => {
     if (DateTime.isDateTime(value)) {
-      return value.toFormat('HH:mm:ssZ');
+      return value.toFormat('HH:mm:ss');
     }
     return null;
   };
@@ -22,8 +22,8 @@ export const TimeWidget = (props: WidgetProps) => {
       // Try parsing as ISO first
       let dateTime = DateTime.fromISO(value);
       if (!dateTime.isValid) {
-        // If not valid ISO, try parsing as HH:mm:ssZ
-        dateTime = DateTime.fromFormat(value, 'HH:mm:ssZ');
+        // If not valid ISO, try parsing as HH:mm:ss
+        dateTime = DateTime.fromFormat(value, 'HH:mm:ss');
       }
       if (dateTime.isValid) {
         return DateTime.fromObject({

--- a/libs/ddhub-client-gateway-frontend/ui/core/src/components/JsonSchemaForm/widgets/index.ts
+++ b/libs/ddhub-client-gateway-frontend/ui/core/src/components/JsonSchemaForm/widgets/index.ts
@@ -3,3 +3,4 @@ export * from './CheckboxesWidget';
 export * from './RadioWidget';
 export * from './SelectWidget';
 export * from './CheckboxWidget';
+export * from './TimeWidget';


### PR DESCRIPTION
Changes:

- Trim clientId (WSS)
- Removed unsupported schema payload format `int32`, `int64`, `binary` and `password`
- Added TimeWidget for custom form
- Modified DateTimeWidget to accept format `date-time` and `date`
- Standardized date format to use `yyyy-MM-dd`
- Standardized time format to use `HH:mm:ss`