### PR TITLE
fix: temporarily disable time format

### DIFF
--- a/apps/dsb-client-gateway-api/src/app/modules/utils/validator/decorators/IsSchemaValid.ts
+++ b/apps/dsb-client-gateway-api/src/app/modules/utils/validator/decorators/IsSchemaValid.ts
@@ -27,7 +27,7 @@ function validateJSONSchema(schema: object, payload: string) {
     mode: 'fast',
     formats: [
       'date',
-      'time',
+      // 'time', -> temporarily disable
       'date-time',
       'duration',
       'uri',


### PR DESCRIPTION
In Project TEDD, `time` is not used as a format. Currently, there's an issue when users just input normal `HH:mm:ss` format as it is not being accepted by the Message Broker.

To temporarily fix the problem, this format is disabled.