### PR TITLE
fix: enforce immediate auth proxy session termination on role change

### DIFF
--- a/apps/dsb-client-gateway-api/src/app/modules/user/login.controller.ts
+++ b/apps/dsb-client-gateway-api/src/app/modules/user/login.controller.ts
@@ -6,7 +6,7 @@ import {
   HttpStatus,
   Post,
 } from '@nestjs/common';
-import { ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import {
   AuthTokens,
   ExcludeAuthRoute,
@@ -16,11 +16,15 @@ import { LoginRequestDto } from './dto/request/login-request.dto';
 import { LoginResponseDto } from './dto/response/login-response.dto';
 import { ConfigResponseDto } from './dto/response/config-response.dto';
 import { RefreshTokenRequestDto } from './dto/request/refresh-token-request.dto';
+import { DidAuthService } from '@dsb-client-gateway/ddhub-client-gateway-did-auth';
 
 @Controller('login')
 @ApiTags('Login')
 export class LoginController {
-  constructor(protected readonly userAuthService: UserAuthService) {}
+  constructor(
+    protected readonly userAuthService: UserAuthService,
+    protected readonly didAuthService: DidAuthService
+  ) {}
 
   @Get('config')
   @HttpCode(HttpStatus.OK)
@@ -77,5 +81,19 @@ export class LoginController {
       role: decodedToken.accountType,
       username: decodedToken.username,
     };
+  }
+
+  @Post('logout')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Logout and invalidate active Auth Proxy sessions',
+    description: 'Explicitly calls the Auth Proxy /auth/logout endpoint to invalidate active sessions associated with the user refresh token.',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Successfully logged out and invalidated Auth Proxy sessions',
+  })
+  public async logout(): Promise<void> {
+    await this.didAuthService.logout();
   }
 }

--- a/apps/dsb-client-gateway-api/src/app/modules/user/user.module.ts
+++ b/apps/dsb-client-gateway-api/src/app/modules/user/user.module.ts
@@ -3,9 +3,14 @@ import { DdhubClientGatewayUserRolesModule } from '@dsb-client-gateway/ddhub-cli
 import { LoginController } from './login.controller';
 import { UserApiKeyController } from './user-apiKey.controller';
 import { SecretsEngineModule } from '@dsb-client-gateway/dsb-client-gateway-secrets-engine';
+import { DidAuthModule } from '@dsb-client-gateway/ddhub-client-gateway-did-auth';
 
 @Module({
-  imports: [DdhubClientGatewayUserRolesModule, SecretsEngineModule],
+  imports: [
+    DdhubClientGatewayUserRolesModule,
+    SecretsEngineModule,
+    DidAuthModule,
+  ],
   controllers: [LoginController, UserApiKeyController],
 })
 export class UserModule { }

--- a/apps/dsb-client-gateway-frontend/next-env.d.ts
+++ b/apps/dsb-client-gateway-frontend/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/apps/dsb-client-gateway-scheduler/src/app/modules/enrolment/enrolment.module.ts
+++ b/apps/dsb-client-gateway-scheduler/src/app/modules/enrolment/enrolment.module.ts
@@ -6,6 +6,7 @@ import { CronRepositoryModule } from '@dsb-client-gateway/dsb-client-gateway-sto
 import { EnrolmentIdentityChangedHandler } from './handler/enrolment-identity-changed.handler';
 import { DdhubClientGatewayEventsModule } from '@dsb-client-gateway/ddhub-client-gateway-events';
 import { CqrsModule } from '@nestjs/cqrs';
+import { DidAuthModule } from '@dsb-client-gateway/ddhub-client-gateway-did-auth';
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { CqrsModule } from '@nestjs/cqrs';
     DdhubClientGatewayEnrolmentModule,
     CronRepositoryModule,
     DdhubClientGatewayEventsModule,
+    DidAuthModule,
   ],
   providers: [
     EnrolmentListenerService,

--- a/apps/dsb-client-gateway-scheduler/src/app/modules/enrolment/service/enrolment-cron.service.ts
+++ b/apps/dsb-client-gateway-scheduler/src/app/modules/enrolment/service/enrolment-cron.service.ts
@@ -16,6 +16,7 @@ import {
 } from '@dsb-client-gateway/ddhub-client-gateway-events';
 import { CommandBus } from '@nestjs/cqrs';
 import { ReloginCommand } from '@dsb-client-gateway/ddhub-client-gateway-message-broker';
+import { DidAuthService } from '@dsb-client-gateway/ddhub-client-gateway-did-auth';
 
 @Injectable()
 export class EnrolmentCronService implements OnApplicationBootstrap {
@@ -28,7 +29,8 @@ export class EnrolmentCronService implements OnApplicationBootstrap {
     protected readonly cronWrapper: CronWrapperRepository,
     protected readonly iamService: IamService,
     protected readonly eventsService: EventsService,
-    protected readonly commandBus: CommandBus
+    protected readonly commandBus: CommandBus,
+    protected readonly didAuthService: DidAuthService
   ) { }
 
   public async onApplicationBootstrap(): Promise<void> {
@@ -135,6 +137,8 @@ export class EnrolmentCronService implements OnApplicationBootstrap {
   }
 
   private async triggerRoleChange(): Promise<void> {
+    this.logger.log('Role change detected. Terminating Auth Proxy sessions.');
+    await this.didAuthService.logout();
     await this.eventsService.triggerEvent(Events.ROLES_CHANGE);
     await this.commandBus.execute(new ReloginCommand('ROLES_CHANGE'));
   }

--- a/libs/ddhub-client-gateway-did-auth/src/lib/service/did-auth-api.service.ts
+++ b/libs/ddhub-client-gateway-did-auth/src/lib/service/did-auth-api.service.ts
@@ -79,4 +79,23 @@ export class DidAuthApiService {
 
     return data;
   }
+
+  public async logout(refreshToken: string): Promise<void> {
+    await lastValueFrom(
+      this.httpService
+        .post(
+          '/auth/logout',
+          {
+            refreshToken,
+            allDevices: true,
+          },
+          {
+            httpsAgent: this.tlsAgentService.get(),
+          }
+        )
+        .pipe(timeout(+this.configService.get<number>('MAX_TIMEOUT', 60000)))
+    ).catch((e) => {
+      this.logger.error(`[Logout Failed][msg] ${e.message}`);
+    });
+  }
 }

--- a/libs/ddhub-client-gateway-did-auth/src/lib/service/did-auth.service.ts
+++ b/libs/ddhub-client-gateway-did-auth/src/lib/service/did-auth.service.ts
@@ -57,4 +57,16 @@ export class DidAuthService {
     this.accessToken = response.access_token;
     this.refreshToken = response.refresh_token;
   }
+
+  public async logout(): Promise<void> {
+    this.logger.log('Attempting to logout and invalidate Auth Proxy sessions');
+
+    if (this.refreshToken) {
+      await this.didAuthApiService.logout(this.refreshToken);
+    }
+
+    // Clear local token state
+    this.accessToken = null;
+    this.refreshToken = null;
+  }
 }

--- a/libs/dsb-client-gateway-api-client/schema.yaml
+++ b/libs/dsb-client-gateway-api-client/schema.yaml
@@ -1456,6 +1456,17 @@ paths:
                 $ref: "#/components/schemas/LoginResponseDto"
       tags:
         - "Login"
+  /api/v2/login/logout:
+    post:
+      description: "Explicitly calls the Auth Proxy /auth/logout endpoint to invalidate active sessions associated with the user refresh token."
+      operationId: "LoginController_logout"
+      parameters: []
+      responses:
+        200:
+          description: "Successfully logged out and invalidated Auth Proxy sessions"
+      summary: "Logout and invalidate active Auth Proxy sessions"
+      tags:
+        - "Login"
   /api/v2/user-api-key/users/me:
     get:
       operationId: "UserApiKeyController_getCurrentUser"
@@ -1777,14 +1788,6 @@ info:
 tags: []
 servers: []
 components:
-  securitySchemes:
-    bearer:
-      scheme: "bearer"
-      bearerFormat: "JWT"
-      type: "http"
-      name: "Authorization"
-      description: "Enter JWT token"
-      in: "header"
   schemas:
     RoleDto:
       type: "object"
@@ -3549,8 +3552,6 @@ components:
             $ref: "#/components/schemas/RequestorFieldDto"
       required:
         - "role"
-security:
-  - bearer: []
 externalDocs:
   description: "Postman Collection"
   url: "/docs-json"


### PR DESCRIPTION
This PR invalidates active user sessions on the Auth Proxy when user roles are updated/revoked 

- Auth Proxy Integration: Added a /auth/logout API request (passing allDevices: true) to clean up sessions tied to the user's refresh token.
- Role Change Trigger: Triggered the logout automatically in EnrolmentCronService upon detecting role changes.
- Exposed API Endpoint: Created a POST /login/logout route in LoginController to support manual frontend client logouts.
- Swagger Update: Updated schema.yaml with the new endpoint.